### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::java::home::symlink()`
 - `p6df::modules::java::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::java::langs()`
 - `p6df::modules::java::vscodes()`
 - `str str = p6df::modules::java::prompt::env()`

--- a/init.zsh
+++ b/init.zsh
@@ -66,7 +66,7 @@ p6df::modules::java::external::brew() {
 ######################################################################
 p6df::modules::java::home::symlink() {
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-java/share/.sonarlint" ".sonarlint"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-java/share/.sonarlint" "$HOME/.sonarlint"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.