### PR TITLE
fix: suppress java_home from prompt env output

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -134,7 +134,9 @@ p6df::modules::java::init() {
 p6df::modules::java::prompt::env() {
 
 #  local str="jenv_root:\t  $JENV_ROOT
-  local str="java_home:\t  $JAVA_HOME"
+#  local str="java_home:\t  $JAVA_HOME"
+
+  local str=""
 
   p6_return_str "$str"
 }


### PR DESCRIPTION
## Summary
- Commented out java_home display in the `prompt::env` function
- Function now returns an empty string, reducing prompt noise

## Test plan
- [ ] Verify `init.zsh` loads without errors
- [ ] Confirm the prompt no longer shows java_home in the env segment
- [ ] Verify other prompt env components still work correctly
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)