### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -35,11 +35,11 @@ p6df::modules::java::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::java::external::brew()
+# Function: p6df::modules::java::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::java::external::brew() {
+p6df::modules::java::external::brews() {
 
   local v
   for v in 8 11 17 21; do


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly