### PR TITLE
chore(java): rename home::symlink to home::symlinks

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -59,12 +59,12 @@ p6df::modules::java::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::java::home::symlink()
+# Function: p6df::modules::java::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
-p6df::modules::java::home::symlink() {
+p6df::modules::java::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-java/share/.sonarlint" "$HOME/.sonarlint"
 


### PR DESCRIPTION
## What
Rename singular to plural so framework auto-discovers it.
## Why
p6df-core dispatches home::symlinks (plural) only.
## Test plan
`p6df home symlinks` works correctly.
## Dependencies
None