### PR TITLE
fix(prompt): use JENV_ROOT and JAVA_HOME env vars in prompt env

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -146,5 +146,5 @@ p6df::modules::java::prompt::lang() {
 ######################################################################
 p6df::modules::java::prompt::env() {
 
-  p6_return_words 'java' "$"
+  p6_return_words 'java' '$JENV_ROOT' '$JAVA_HOME'
 }


### PR DESCRIPTION
## What
Fix `p6df::modules::java::prompt::env` to pass `$JENV_ROOT` and `$JAVA_HOME` environment variables instead of the broken `"$"` literal.

## Why
The previous value `"$"` was a broken placeholder. The correct Java environment variables `$JENV_ROOT` and `$JAVA_HOME` are now referenced so the prompt env function exposes them properly.

## Test plan
- Reviewed diff; single-line fix replacing `"$"` with `'$JENV_ROOT' '$JAVA_HOME'`
- No functional regressions expected; this fixes a non-functional placeholder

## Dependencies
None