### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::java::deps()
-#
-#>
-######################################################################
 p6df::modules::java::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -14,30 +8,21 @@ p6df::modules::java::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::java::vscodes()
-#
-#>
-######################################################################
-p6df::modules::java::vscodes() {
+p6df::modules::java::langmgr::init() {
 
-  p6df::modules::vscode::extension::install SonarSource.sonarlint-vscode
-  p6df::modules::vscode::extension::install redhat.java
-  p6df::modules::vscode::extension::install vscjava.vscode-java-debug
-  p6df::modules::vscode::extension::install vscjava.vscode-java-dependency
-  p6df::modules::vscode::extension::install vscjava.vscode-java-test
-  p6df::modules::vscode::extension::install vscjava.vscode-maven
+  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/gcuisinier/jenv" "j"
 
   p6_return_void
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::java::external::brews()
-#
-#>
+p6df::modules::java::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-java/share/.sonarlint" "$HOME/.sonarlint"
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::java::external::brews() {
 
@@ -56,28 +41,6 @@ p6df::modules::java::external::brews() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::java::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::java::home::symlinks() {
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-java/share/.sonarlint" "$HOME/.sonarlint"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::java::langs()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
 ######################################################################
 p6df::modules::java::langs() {
 
@@ -98,20 +61,57 @@ p6df::modules::java::langs() {
 }
 
 ######################################################################
+p6df::modules::java::vscodes() {
+
+  p6df::modules::vscode::extension::install SonarSource.sonarlint-vscode
+  p6df::modules::vscode::extension::install redhat.java
+  p6df::modules::vscode::extension::install vscjava.vscode-java-debug
+  p6df::modules::vscode::extension::install vscjava.vscode-java-dependency
+  p6df::modules::vscode::extension::install vscjava.vscode-java-test
+  p6df::modules::vscode::extension::install vscjava.vscode-maven
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6df::modules::java::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::java::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::java::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::java::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::java::langs()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
+######################################################################
 #<
 #
 # Function: p6df::modules::java::langmgr::init()
 #
 #  Environment:	 P6_DFZ_SRC_DIR
 #>
-######################################################################
-p6df::modules::java::langmgr::init() {
-
-  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/gcuisinier/jenv" "j"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::java::deps()
+#
+#>
+######################################################################
 p6df::modules::java::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -7,6 +13,13 @@ p6df::modules::java::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::java::langmgr::init()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::java::langmgr::init() {
 
@@ -16,6 +29,13 @@ p6df::modules::java::langmgr::init() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::java::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
+######################################################################
 p6df::modules::java::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-java/share/.sonarlint" "$HOME/.sonarlint"
@@ -23,6 +43,12 @@ p6df::modules::java::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::java::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::java::external::brews() {
 
@@ -41,6 +67,13 @@ p6df::modules::java::external::brews() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::java::langs()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::java::langs() {
 
@@ -61,6 +94,12 @@ p6df::modules::java::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::java::vscodes()
+#
+#>
+######################################################################
 p6df::modules::java::vscodes() {
 
   p6df::modules::vscode::extension::install SonarSource.sonarlint-vscode
@@ -73,45 +112,6 @@ p6df::modules::java::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::java::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::java::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::java::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::java::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::java::langs()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::java::langmgr::init()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None