### PR TITLE
refactor(java): update function signatures and rename prompt::env return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,13 @@ TODO: Add a short summary of this module.
 ##### p6df-java/init.zsh
 
 - `p6df::modules::java::deps()`
-- `p6df::modules::java::external::brew()`
-- `p6df::modules::java::home::symlink()`
-- `p6df::modules::java::init(_module, dir)`
-  - Args:
-    - _module -
-    - dir -
+- `p6df::modules::java::external::brews()`
+- `p6df::modules::java::home::symlinks()`
+- `p6df::modules::java::langmgr::init()`
 - `p6df::modules::java::langs()`
 - `p6df::modules::java::vscodes()`
-- `str str = p6df::modules::java::prompt::env()`
 - `str str = p6df::modules::java::prompt::lang()`
+- `words java = p6df::modules::java::prompt::env()`
 
 #### p6df-java/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -136,12 +136,12 @@ p6df::modules::java::prompt::lang() {
 ######################################################################
 #<
 #
-# Function: words java $JAVA_HOME = p6df::modules::java::prompt::env()
+# Function: words java = p6df::modules::java::prompt::env()
 #
 #  Returns:
-#	words - java $JAVA_HOME
+#	words - java
 #
-#  Environment:	 JAVA_HOME
+#  Environment:	 JAVA_HOME JENV_ROOT
 #>
 ######################################################################
 p6df::modules::java::prompt::env() {


### PR DESCRIPTION
**What:** Update function signatures with proper arg names and fix prompt::env return type declaration

**Why:** Normalizes function documentation to use consistent `words java` return type, renames `external::brew` to `external::brews`, and adds `langmgr::init`

**Test plan:** Shell loads without errors; java prompt functions return expected values

**Dependencies:** none